### PR TITLE
Swagger 3.0 설정 및 CI 구현

### DIFF
--- a/.github/workflows/SpringBoot-CI.yml
+++ b/.github/workflows/SpringBoot-CI.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+      - name: Gradle 명령 실행을 위한 권한을 부여합니다
+        run: chmod +x gradlew
       - name: Cache Gradle dependencies
         uses: actions/cache@v2
         with:

--- a/.github/workflows/SpringBoot-CI.yml
+++ b/.github/workflows/SpringBoot-CI.yml
@@ -14,11 +14,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-<<<<<<< HEAD
-          distribution: 'adopt'
-=======
           distribution: 'temurin'
->>>>>>> 93defeecafca0e0acc1af23a890cd2368d461ba5
       - name: Gradle 명령 실행을 위한 권한을 부여합니다
         run: chmod +x gradlew
       - name: Cache Gradle dependencies

--- a/.github/workflows/SpringBoot-CI.yml
+++ b/.github/workflows/SpringBoot-CI.yml
@@ -1,0 +1,32 @@
+name: Spring Boot CI
+on:
+  pull_request:
+    branches:
+      - weekly  # 'weekly' 브랜치로 PR이 생성될 때만 실행
+jobs:
+  build:
+    runs-on: ubuntu-latest # job 가상환경 설정
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build and Test
+        run: ./gradlew clean build
+      - name: Run Spring Boot App for 30 seconds
+        run: |
+          ./gradlew bootRun &
+          APP_PID=$!
+          sleep 30
+          kill $APP_PID
+        continue-on-error: false

--- a/.github/workflows/SpringBoot-CI.yml
+++ b/.github/workflows/SpringBoot-CI.yml
@@ -30,3 +30,14 @@ jobs:
           sleep 30
           kill $APP_PID
         continue-on-error: false
+      - name: 테스트 결과를 PR에 코멘트로 등록합니다
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          files: '**/build/test-results/test/TEST-*.xml'
+      - name: 테스트 실패 시, 실패한 코드 라인에 Check 코멘트를 등록합니다
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+          token: ${{ github.token }}

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ dependencies {
 
 	// local, test : h2
 	runtimeOnly 'com.h2database:h2'
+
+	// swagger
+	implementation 'io.springfox:springfox-boot-starter:3.0.0'
+	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/demo/account/AccountRestController.java
+++ b/src/main/java/com/example/demo/account/AccountRestController.java
@@ -1,6 +1,7 @@
 package com.example.demo.account;
 
 import com.example.demo.config.utils.ApiUtils;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,7 @@ public class AccountRestController {
     private final AccountService accountService;
 
     @PostMapping(value = "/users/signup")
+    @Operation(summary = "회원가입", description = "SignUpDTO 를 받아서 회원가입 진행")
     public ResponseEntity<?> signup(@RequestPart @Valid AccountRequest.SignUpDTO requestDTO, Errors errors) {
         accountService.signup(requestDTO);
         return ResponseEntity.ok().body(ApiUtils.success(true));

--- a/src/main/java/com/example/demo/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/example/demo/config/swagger/SwaggerConfig.java
@@ -1,0 +1,38 @@
+package com.example.demo.config.swagger;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Contact;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+    private String version = "V0.1";
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
+                .paths(PathSelectors.any())
+                .build()
+                .apiInfo(apiInfo());
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("제목")
+                .description("설명")
+                .version(version)
+                .contact(new Contact("이름", "홈페이지 URL", "e-mail"))
+                .build();
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,3 +22,6 @@ spring:
         format_sql: true
       default_batch_fetch_size: 100
     open-in-view: false
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher # spring 2.6 ↑

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -22,3 +22,6 @@ spring:
         format_sql: true
       default_batch_fetch_size: 100
     open-in-view: false
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher # spring 2.6 ↑


### PR DESCRIPTION
# Summary

## Swagger

- SwaggerConfig.java 파일을 추가하여, **Swagger 기능 활성화**하였습니다.
- **RestController 에너테이션이 설정되어 있는 클래스만 Swagger 에 나오도록 설정**했습니다.
- Spring 2.6 버전 이후부터 발생하는 에러인 **경로 에러**를 해결하기 위해 application-local.yml 파일에 경로 설정을 해주었습니다.

**swagger 화면** ( url : http://localhost:8080/swagger-ui/index.html )
![swagger](https://github.com/Step3-kakao-tech-campus/Team18_BE/assets/111727212/803b931d-d0bc-4cc2-b750-5e847b4d2fb2)

## github Action CI

- 깃허브 액션의 CI 기능을 활용하여, **weekly 로 PR 을 보낼경우 빌드 테스트를 진행**합니다.
- swagger 경로 에러때문에, **application-test.yml 파일에도 경로 설정**을 해주었습니다.
- java 11 버전을 사용하기에, **일부 코드를 수정**하였습니다.
- 추가로 build 를 수행한 후 **테스트 결과에 대한 내용을 담은 파일이 생성되는 기능**을 추가하였습니다.
- 추가로 **오류가 발생한 코드라인에 Check 코멘트가 자동 생성되는 기능**을 추가하였습니다.

### 예시
**실패 예시**
![CI 실패](https://github.com/Step3-kakao-tech-campus/Team18_BE/assets/111727212/e14f830a-a0b8-40bb-99be-649f90b08c13)

**성공 예시**
![CI 성공](https://github.com/Step3-kakao-tech-campus/Team18_BE/assets/111727212/8c07f4a8-e00e-40ca-8564-ff4c85382ccd)

## 할일

- 나중에 SwaggerConfig 의 apiInfo 메소드만 조금 수정해주면 될 것 같습니다.
