### PR TITLE
[ 멘토 기준 ] contact 화면 조회 기능 추가

### DIFF
--- a/src/main/java/com/example/demo/account/Account.java
+++ b/src/main/java/com/example/demo/account/Account.java
@@ -14,7 +14,7 @@ import javax.persistence.*;
 public class Account {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int uid;
+    private int id;
 
     @Column(length = 50, nullable = false, unique = true)
     private String email;
@@ -49,8 +49,8 @@ public class Account {
     }
 
     @Builder
-    public Account(int uid, String email, String password, String firstname, String lastname, String country, String introduction, int age, String profileImage, Role role){
-        this.uid = uid;
+    public Account(int id, String email, String password, String firstname, String lastname, String country, String introduction, int age, String profileImage, Role role){
+        this.id = id;
         this.email = email;
         this.password = password;
         this.firstname = firstname;

--- a/src/main/java/com/example/demo/account/AccountJPARepository.java
+++ b/src/main/java/com/example/demo/account/AccountJPARepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface AccountJPARepository extends JpaRepository<Account, Integer> {
     Optional<Account> findByEmail(String email);
+
+    Account findById(int id);
 }

--- a/src/main/java/com/example/demo/account/interest/Interest.java
+++ b/src/main/java/com/example/demo/account/interest/Interest.java
@@ -1,0 +1,27 @@
+package com.example.demo.account.interest;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "interest")
+public class Interest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    private String tag;
+
+    @Builder
+    public Interest(int id, String tag) {
+        this.id = id;
+        this.tag = tag;
+    }
+}

--- a/src/main/java/com/example/demo/account/interest/InterestJPARepository.java
+++ b/src/main/java/com/example/demo/account/interest/InterestJPARepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.account.interest;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InterestJPARepository extends JpaRepository<Interest, Integer> {
+
+}

--- a/src/main/java/com/example/demo/account/userInterest/UserInterest.java
+++ b/src/main/java/com/example/demo/account/userInterest/UserInterest.java
@@ -26,7 +26,7 @@ public class UserInterest {
     private Interest interest;
 
     @Builder
-    public UserInterest(int id, Account account, Interest interest) {
+    public UserInterest(int id, Account user, Interest interest) {
         this.id = id;
         this.user = user;
         this.interest = interest;

--- a/src/main/java/com/example/demo/account/userInterest/UserInterest.java
+++ b/src/main/java/com/example/demo/account/userInterest/UserInterest.java
@@ -1,0 +1,34 @@
+package com.example.demo.account.userInterest;
+
+import com.example.demo.account.Account;
+import com.example.demo.account.interest.Interest;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "userInterest")
+public class UserInterest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @ManyToOne
+    private Account user;
+
+    @ManyToOne
+    private Interest interest;
+
+    @Builder
+    public UserInterest(int id, Account account, Interest interest) {
+        this.id = id;
+        this.user = user;
+        this.interest = interest;
+    }
+}

--- a/src/main/java/com/example/demo/account/userInterest/UserInterestJPARepository.java
+++ b/src/main/java/com/example/demo/account/userInterest/UserInterestJPARepository.java
@@ -2,11 +2,12 @@ package com.example.demo.account.userInterest;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface UserInterestJPARepository extends JpaRepository<UserInterest, Integer> {
-    @Query("select u from UserInterest u join fetch Interest i where u.user.id = :id")
-    List<UserInterest> findAllById(int id);
+    @Query("select u from UserInterest u join fetch u.interest i where u.user.id = :id")
+    List<UserInterest> findAllById(@Param("id") int id);
 
 }

--- a/src/main/java/com/example/demo/account/userInterest/UserInterestJPARepository.java
+++ b/src/main/java/com/example/demo/account/userInterest/UserInterestJPARepository.java
@@ -1,0 +1,12 @@
+package com.example.demo.account.userInterest;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface UserInterestJPARepository extends JpaRepository<UserInterest, Integer> {
+    @Query("select u from UserInterest u join fetch Interest i where u.user.id = :id")
+    List<UserInterest> findAllById(int id);
+
+}

--- a/src/main/java/com/example/demo/config/jwt/JWTAuthenticationFilter.java
+++ b/src/main/java/com/example/demo/config/jwt/JWTAuthenticationFilter.java
@@ -35,9 +35,9 @@ public class JWTAuthenticationFilter extends BasicAuthenticationFilter {
 
         try {
             DecodedJWT decodedJWT = JWTTokenProvider.verify(jwt);
-            int uid = decodedJWT.getClaim("user_id").asInt();
+            int id = decodedJWT.getClaim("user_id").asInt();
             String email = decodedJWT.getClaim("user_email").asString();
-            Account user = Account.builder().uid(uid).email(email).build();
+            Account user = Account.builder().id(id).email(email).build();
             CustomUserDetails customUserDetails = new CustomUserDetails(user);
             Authentication authentication =
                     new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/example/demo/config/jwt/JWTTokenProvider.java
+++ b/src/main/java/com/example/demo/config/jwt/JWTTokenProvider.java
@@ -21,7 +21,7 @@ public class JWTTokenProvider {
         String jwt = JWT.create()
                 .withSubject(account.getEmail())
                 .withExpiresAt(new Date(System.currentTimeMillis() + EXP))
-                .withClaim("user_id", account.getUid())
+                .withClaim("user_id", account.getId())
                 .withClaim("user_email", account.getEmail())
                 .sign(Algorithm.HMAC512(SECRET));
         return TOKEN_PREFIX + jwt;

--- a/src/main/java/com/example/demo/mentoring/MentorPost.java
+++ b/src/main/java/com/example/demo/mentoring/MentorPost.java
@@ -1,0 +1,35 @@
+package com.example.demo.mentoring;
+
+import com.example.demo.account.Account;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "mentorPost")
+public class MentorPost {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Account writer;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String context;
+
+    @Builder
+    public MentorPost(int id, Account writer, String title, String context){
+        this.id = id;
+        this.writer = writer;
+        this.title = title;
+        this.context = context;
+    }
+}

--- a/src/main/java/com/example/demo/mentoring/MentorPostJPARepostiory.java
+++ b/src/main/java/com/example/demo/mentoring/MentorPostJPARepostiory.java
@@ -1,11 +1,15 @@
 package com.example.demo.mentoring;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface MentorPostJPARepostiory extends JpaRepository<MentorPost, Integer> {
-    List<MentorPost> findAllByWriter(int writer);
+
+    @Query("select m from MentorPost m where m.writer.id = :writer")
+    List<MentorPost> findAllByWriter(@Param("writer") int writer);
 
     MentorPost findById(int id);
 }

--- a/src/main/java/com/example/demo/mentoring/MentorPostJPARepostiory.java
+++ b/src/main/java/com/example/demo/mentoring/MentorPostJPARepostiory.java
@@ -1,0 +1,11 @@
+package com.example.demo.mentoring;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MentorPostJPARepostiory extends JpaRepository<MentorPost, Integer> {
+    List<MentorPost> findAllByWriter(int writer);
+
+    MentorPost findById(int id);
+}

--- a/src/main/java/com/example/demo/mentoring/contact/ContactJPARepository.java
+++ b/src/main/java/com/example/demo/mentoring/contact/ContactJPARepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.mentoring.contact;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ContactJPARepository extends JpaRepository<NotConnectedRegisterUser, Integer> {
+
+    List<NotConnectedRegisterUser> findAllByMentorPostId(int mentorPostId);
+
+}

--- a/src/main/java/com/example/demo/mentoring/contact/ContactJPARepository.java
+++ b/src/main/java/com/example/demo/mentoring/contact/ContactJPARepository.java
@@ -1,11 +1,14 @@
 package com.example.demo.mentoring.contact;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ContactJPARepository extends JpaRepository<NotConnectedRegisterUser, Integer> {
 
-    List<NotConnectedRegisterUser> findAllByMentorPostId(int mentorPostId);
+    @Query("SELECT ncru FROM NotConnectedRegisterUser ncru WHERE ncru.mentorPost.id = :mentorPostId")
+    List<NotConnectedRegisterUser> findAllByMentorPostId(@Param("mentorPostId") int mentorPostId);
 
 }

--- a/src/main/java/com/example/demo/mentoring/contact/ContactRequest.java
+++ b/src/main/java/com/example/demo/mentoring/contact/ContactRequest.java
@@ -1,0 +1,4 @@
+package com.example.demo.mentoring.contact;
+
+public class ContactRequest {
+}

--- a/src/main/java/com/example/demo/mentoring/contact/ContactResponse.java
+++ b/src/main/java/com/example/demo/mentoring/contact/ContactResponse.java
@@ -41,6 +41,7 @@ public class ContactResponse {
             private String name;
             private String country;
             private int age;
+            private Account.Role role;
             private List<String> favorites;
 
             public MentorDTO(Account account, List<UserInterest> userInterests) {
@@ -49,8 +50,9 @@ public class ContactResponse {
                 this.name = account.getFirstname() + " " + account.getLastname();
                 this.country = account.getCountry();
                 this.age = account.getAge();
+                this.role = account.getRole();
                 this.favorites = userInterests.stream()
-                        .filter(userInterest -> userInterest.getUser().getId() == this.mentorId)
+                        .filter(userInterest -> userInterest.getUser().getId() == account.getId())
                         .map(userInterest -> userInterest.getInterest().getTag())
                         .collect(Collectors.toList());
             }
@@ -62,6 +64,7 @@ public class ContactResponse {
             private String name;
             private String country;
             private int age;
+            private Account.Role role;
             private List<String> favorites; // 고민할 부분 : 유저의 favorite List 를 어떻게 가져올 것 인가?
 
             /**
@@ -77,8 +80,9 @@ public class ContactResponse {
                 this.name = notConnectedRegisterUser.getMenteeUser().getFirstname() + " " + notConnectedRegisterUser.getMenteeUser().getLastname();
                 this.country = notConnectedRegisterUser.getMenteeUser().getCountry();
                 this.age = notConnectedRegisterUser.getMenteeUser().getAge();
+                this.role = notConnectedRegisterUser.getMenteeUser().getRole();
                 this.favorites = userInterests.stream()
-                        .filter(userInterest -> userInterest.getUser().getId() == this.menteeId)
+                        .filter(userInterest -> userInterest.getUser().getId() == notConnectedRegisterUser.getMenteeUser().getId())
                         .map(userInterest -> userInterest.getInterest().getTag())
                         .collect(Collectors.toList());
             }

--- a/src/main/java/com/example/demo/mentoring/contact/ContactResponse.java
+++ b/src/main/java/com/example/demo/mentoring/contact/ContactResponse.java
@@ -65,6 +65,7 @@ public class ContactResponse {
             private String country;
             private int age;
             private Account.Role role;
+            private NotConnectedRegisterUser.State state;
             private List<String> favorites; // 고민할 부분 : 유저의 favorite List 를 어떻게 가져올 것 인가?
 
             /**
@@ -81,6 +82,7 @@ public class ContactResponse {
                 this.country = notConnectedRegisterUser.getMenteeUser().getCountry();
                 this.age = notConnectedRegisterUser.getMenteeUser().getAge();
                 this.role = notConnectedRegisterUser.getMenteeUser().getRole();
+                this.state = notConnectedRegisterUser.getState();
                 this.favorites = userInterests.stream()
                         .filter(userInterest -> userInterest.getUser().getId() == notConnectedRegisterUser.getMenteeUser().getId())
                         .map(userInterest -> userInterest.getInterest().getTag())

--- a/src/main/java/com/example/demo/mentoring/contact/ContactResponse.java
+++ b/src/main/java/com/example/demo/mentoring/contact/ContactResponse.java
@@ -1,0 +1,86 @@
+package com.example.demo.mentoring.contact;
+
+import com.example.demo.account.Account;
+import com.example.demo.account.userInterest.UserInterest;
+import com.example.demo.mentoring.MentorPost;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ContactResponse {
+    /**
+     *
+     * DTO 담는 순서
+     * 1. MenteeDTO : Parameter ( NotConnectedRegisterUser, List<UserInterest> )
+     * 여기서 NotConnectedRegisterUser 를 리팩토링해서, 아예 Mentee 부분만 빼와도 될듯 하다.
+     * 2. MentorDTO : Parameter ( Account -> 나중에 User 로 바꿔야 함, List<UserInterest> -> mentor 의 tags )
+     * 3. MentorPostDTO : Parameter ( MentorPost, List<MentorDTO>, List<MenteeDTO> )
+     *
+     * **/
+    @Getter @Setter
+    public static class MentorPostDTO {
+        private int postId;
+        private String title;
+        private MentorDTO mentors;
+        private List<MenteeDTO> mentees;
+
+        public MentorPostDTO(MentorPost mentorPost, MentorDTO mentors, List<MenteeDTO> mentees) {
+            this.postId = mentorPost.getId();
+            this.title = mentorPost.getTitle();
+            this.mentors = mentors;
+            this.mentees = mentees;
+        }
+    }
+
+        @Getter @Setter
+        public static class MentorDTO {
+            private int mentorId;
+            private String profileImage;
+            private String name;
+            private String country;
+            private int age;
+            private List<String> favorites;
+
+            public MentorDTO(Account account, List<UserInterest> userInterests) {
+                this.mentorId = account.getId();
+                this.profileImage = account.getProfileImage();
+                this.name = account.getFirstname() + " " + account.getLastname();
+                this.country = account.getCountry();
+                this.age = account.getAge();
+                this.favorites = userInterests.stream()
+                        .filter(userInterest -> userInterest.getUser().getId() == this.mentorId)
+                        .map(userInterest -> userInterest.getInterest().getTag())
+                        .collect(Collectors.toList());
+            }
+        }
+        @Getter @Setter
+        public static class MenteeDTO {
+            private int menteeId;
+            private String profileImage;
+            private String name;
+            private String country;
+            private int age;
+            private List<String> favorites; // 고민할 부분 : 유저의 favorite List 를 어떻게 가져올 것 인가?
+
+            /**
+             * 유저의 favorite List 를 가져오기 위해
+             * userInterest 를 입력으로 받음
+             * userInterest 의 userId 와 현재 신청한 멘티 ( notConnectedRegitserUser ) 의 id 값이 일치하는 경우
+             * 그럴 경우에만 tag 값들을 가져오기
+             * **/
+
+            public MenteeDTO(NotConnectedRegisterUser notConnectedRegisterUser, List<UserInterest> userInterests) {
+                this.menteeId = notConnectedRegisterUser.getMenteeUser().getId();
+                this.profileImage = notConnectedRegisterUser.getMenteeUser().getProfileImage();
+                this.name = notConnectedRegisterUser.getMenteeUser().getFirstname() + " " + notConnectedRegisterUser.getMenteeUser().getLastname();
+                this.country = notConnectedRegisterUser.getMenteeUser().getCountry();
+                this.age = notConnectedRegisterUser.getMenteeUser().getAge();
+                this.favorites = userInterests.stream()
+                        .filter(userInterest -> userInterest.getUser().getId() == this.menteeId)
+                        .map(userInterest -> userInterest.getInterest().getTag())
+                        .collect(Collectors.toList());
+            }
+        }
+}

--- a/src/main/java/com/example/demo/mentoring/contact/ContactResponse.java
+++ b/src/main/java/com/example/demo/mentoring/contact/ContactResponse.java
@@ -23,13 +23,13 @@ public class ContactResponse {
     public static class MentorPostDTO {
         private int postId;
         private String title;
-        private MentorDTO mentors;
+        private MentorDTO mentor;
         private List<MenteeDTO> mentees;
 
-        public MentorPostDTO(MentorPost mentorPost, MentorDTO mentors, List<MenteeDTO> mentees) {
+        public MentorPostDTO(MentorPost mentorPost, MentorDTO mentor, List<MenteeDTO> mentees) {
             this.postId = mentorPost.getId();
             this.title = mentorPost.getTitle();
-            this.mentors = mentors;
+            this.mentor = mentor;
             this.mentees = mentees;
         }
     }

--- a/src/main/java/com/example/demo/mentoring/contact/ContactRestController.java
+++ b/src/main/java/com/example/demo/mentoring/contact/ContactRestController.java
@@ -1,0 +1,27 @@
+package com.example.demo.mentoring.contact;
+
+import com.example.demo.config.auth.CustomUserDetails;
+import com.example.demo.config.utils.ApiUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class ContactRestController {
+
+    private final ContactService contactService;
+
+    @GetMapping(value = "/contacts")
+    @Operation(summary = "", description = "")
+    public ResponseEntity<?> findAll(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<ContactResponse.MentorPostDTO> responseDTO = contactService.findAll(userDetails.getAccount());
+        return ResponseEntity.ok(ApiUtils.success(responseDTO));
+    }
+
+}

--- a/src/main/java/com/example/demo/mentoring/contact/ContactService.java
+++ b/src/main/java/com/example/demo/mentoring/contact/ContactService.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Service
 public class ContactService {
-    // userId 에 해당하는 mentorPost 들을 전부 가져와야 함
+
     private final MentorPostJPARepostiory mentorPostJPARepostiory;
     private final AccountJPARepository accountJPARepository;
     private final ContactJPARepository contactJPARepository;
@@ -45,8 +45,8 @@ public class ContactService {
              * - 멘토의 정보를 만들기 위해 필요한 값 : mentor 의 account, mentor 의 interests
              * - account 는 조회하면 되니, 바로 구할 수 있다.
              * - userInterest 에서 멘토의 interest 값들을 가져올 수 있기 때문에, userInterest 와 interest 를 join 후 tag 들을 가져온다.
-             * 3. mentorPosts 를 활용하여 for문을 돌면서 mentorPost 1개 + mentor 정보 1개 + mentor 정보 여러개 의 꼴로 DTO 를 만든다.
-             * - mentor 의 정보를 만들기 위해 필요한 값 : notConnectedRegisterUser 에서 mentor 의 정보, mentor 의 interests
+             * 3. mentorPosts 를 활용하여 for문을 돌면서 mentorPost 1개 + mentor 정보 1개 + mentee 정보 여러개 의 꼴로 DTO 를 만든다.
+             * - mentee 의 정보를 만들기 위해 필요한 값 : notConnectedRegisterUser 에서 mentee 의 정보, mentee 의 interests
              * - 신청한 멘티들의 정보를 가져오기 위해 notConnectedRegisterUser 의 테이블과 , 각 멘티에 해당하는 interests 들을 묶어서 DTO 로 만들기 ( 그래서 List<MenteeDTO> 를 만듬 )
              * - 싹다 묶어서 reponseDTOs 로 전달
              * **/

--- a/src/main/java/com/example/demo/mentoring/contact/ContactService.java
+++ b/src/main/java/com/example/demo/mentoring/contact/ContactService.java
@@ -1,0 +1,96 @@
+package com.example.demo.mentoring.contact;
+
+import com.example.demo.account.Account;
+import com.example.demo.account.AccountJPARepository;
+import com.example.demo.account.userInterest.UserInterest;
+import com.example.demo.account.userInterest.UserInterestJPARepository;
+import com.example.demo.mentoring.MentorPost;
+import com.example.demo.mentoring.MentorPostJPARepostiory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class ContactService {
+    // userId 에 해당하는 mentorPost 들을 전부 가져와야 함
+    private final MentorPostJPARepostiory mentorPostJPARepostiory;
+    private final AccountJPARepository accountJPARepository;
+    private final ContactJPARepository contactJPARepository;
+    private final UserInterestJPARepository userInterestJPARepository;
+
+    /**
+     * findAll : dashboard - contact 부분 화면에 필요한 DTO를 응답해주는 함수
+     * parameter : Account ( 유저의 계정 )
+     * **/
+    public List<ContactResponse.MentorPostDTO> findAll(Account account) {
+        // account 의 id 값
+        int id = account.getId();
+
+        // 분기 - 유저가 멘토인지, 멘티인지
+        if ( account.getRole() == Account.Role.MENTEE ) {
+            // TO-DO : Mentee 입장에서 조회하는 부분 작성하기
+            return null;
+        }
+        else {
+            /**
+             * 흐름 ( 멘토 입장 )
+             * 1. 내가 작성한 게시글 ( mentorPosts ) 들을 조회해서 가져온다.
+             * 2. 멘토의 정보는 mentorPosts 와 별개로 한번에 조회되는 값이니, for문 밖으로 빼서 조회한다.
+             * - 멘토의 정보를 만들기 위해 필요한 값 : mentor 의 account, mentor 의 interests
+             * - account 는 조회하면 되니, 바로 구할 수 있다.
+             * - userInterest 에서 멘토의 interest 값들을 가져올 수 있기 때문에, userInterest 와 interest 를 join 후 tag 들을 가져온다.
+             * 3. mentorPosts 를 활용하여 for문을 돌면서 mentorPost 1개 + mentor 정보 1개 + mentor 정보 여러개 의 꼴로 DTO 를 만든다.
+             * - mentor 의 정보를 만들기 위해 필요한 값 : notConnectedRegisterUser 에서 mentor 의 정보, mentor 의 interests
+             * - 신청한 멘티들의 정보를 가져오기 위해 notConnectedRegisterUser 의 테이블과 , 각 멘티에 해당하는 interests 들을 묶어서 DTO 로 만들기 ( 그래서 List<MenteeDTO> 를 만듬 )
+             * - 싹다 묶어서 reponseDTOs 로 전달
+             * **/
+            // Return 할 객체
+            List<ContactResponse.MentorPostDTO> responseDTOs = new ArrayList<>();
+
+            // 멘토의 id 에 해당하는 mentorPost 다 가져오기
+            List<MentorPost> mentorPosts = mentorPostJPARepostiory.findAllByWriter(id);
+
+            // 멘토 정보 가져오기 ( 나중에 User 로 바꿔야 함 )
+            Account mentorAccount = accountJPARepository.findById(id);
+            // List<UserInterest> 가져오기 ( 멘토꺼 tag 목록 )
+            List<UserInterest> mentorInterests = userInterestJPARepository.findAllById(mentorAccount.getId());
+
+            // MentorDTO 담기
+            ContactResponse.MentorDTO mentorDTO = new ContactResponse.MentorDTO(mentorAccount, mentorInterests);
+
+            // 만약 3개의 글을 썼을 경우, 현재 mentorPosts 에는 3개의 글 목록이 존재함
+            for ( MentorPost mentorPost : mentorPosts ) {
+                // List<MenteeDTO> 만들기
+                // 신청한 멘티의 목록 ( postId 로 조회 )
+                List<NotConnectedRegisterUser> mentees = contactJPARepository.findAllByMentorPostId(mentorPost.getId());
+
+                // List<MenteeDTO> 생성
+                List<ContactResponse.MenteeDTO> menteeDTOs = mentees
+                        .stream()
+                        .map(this::createMenteeDTO)
+                        .collect(Collectors.toList());
+                // responseDTO 에 담기
+                responseDTOs.add(new ContactResponse.MentorPostDTO(mentorPost, mentorDTO, menteeDTOs));
+
+            }
+            return responseDTOs;
+        }
+
+    }
+
+    // 매핑 로직 분리 ( menteeDTO 생성 로직 )
+    private ContactResponse.MenteeDTO createMenteeDTO(NotConnectedRegisterUser mentee) {
+
+        List<UserInterest> menteeInterests = userInterestJPARepository
+                .findAllById(mentee.getMenteeUser().getId());
+
+        return new ContactResponse.MenteeDTO(mentee, menteeInterests);
+    }
+
+}

--- a/src/main/java/com/example/demo/mentoring/contact/NotConnectedRegisterUser.java
+++ b/src/main/java/com/example/demo/mentoring/contact/NotConnectedRegisterUser.java
@@ -1,0 +1,41 @@
+package com.example.demo.mentoring.contact;
+
+import com.example.demo.account.Account;
+import com.example.demo.mentoring.MentorPost;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "notConnectedRegisterUser")
+public class NotConnectedRegisterUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @OneToOne
+    private MentorPost mentorPost;
+
+    @ManyToOne
+    private Account menteeUser;
+
+    private State state;
+
+    public enum State {
+        ACCEPT, REFUSE, AWAIT
+    }
+
+    @Builder
+    public NotConnectedRegisterUser(int id, MentorPost mentorPost, Account menteeUser, State state) {
+        this.id = id;
+        this.mentorPost = mentorPost;
+        this.menteeUser = menteeUser;
+        this.state = state;
+    }
+}

--- a/src/main/java/com/example/demo/mentoring/done/ConnectedUser.java
+++ b/src/main/java/com/example/demo/mentoring/done/ConnectedUser.java
@@ -1,0 +1,34 @@
+package com.example.demo.mentoring.done;
+
+import com.example.demo.account.Account;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "connectedUser")
+public class ConnectedUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @ManyToOne
+    private Account mentorUser;
+
+    @ManyToOne
+    private Account menteeUser;
+
+    @Builder
+    public ConnectedUser(int id, Account mentorUser, Account menteeUser) {
+        this.id = id;
+        this.mentorUser = mentorUser;
+        this.menteeUser = menteeUser;
+    }
+
+}

--- a/src/test/java/com/example/demo/AccountTest.java
+++ b/src/test/java/com/example/demo/AccountTest.java
@@ -21,7 +21,7 @@ public class AccountTest {
     @DisplayName("account save test")
     void test() {
         Account account = Account.builder()
-                .uid(1)
+                .id(1)
                 .email("anjdal64@gmail.com")
                 .password("asdf1234!")
                 .firstname("Jin")
@@ -35,7 +35,7 @@ public class AccountTest {
         accountJPARepository.save(account);
 
         // find
-        Account account1 = accountJPARepository.findById(account.getId()).get();
+        Account account1 = accountJPARepository.findById(account.getId());
         Assertions.assertThat(account.getId())
                 .isEqualTo(account1.getId());
     }

--- a/src/test/java/com/example/demo/AccountTest.java
+++ b/src/test/java/com/example/demo/AccountTest.java
@@ -35,8 +35,8 @@ public class AccountTest {
         accountJPARepository.save(account);
 
         // find
-        Account account1 = accountJPARepository.findById(account.getUid()).get();
-        Assertions.assertThat(account.getUid())
-                .isEqualTo(account1.getUid());
+        Account account1 = accountJPARepository.findById(account.getId()).get();
+        Assertions.assertThat(account.getId())
+                .isEqualTo(account1.getId());
     }
 }

--- a/src/test/java/com/example/demo/contactTest.java
+++ b/src/test/java/com/example/demo/contactTest.java
@@ -149,11 +149,6 @@ public class contactTest {
 
         List<ContactResponse.MentorPostDTO> responseDTOs = contactService.findAll(account1);
 
-        List<UserInterest> menteeInterests = userInterestJPARepository.findAllById(2);
-        List<UserInterest> userInterests = userInterestJPARepository.findAll();
-
-        System.out.println(menteeInterests.size());
-
         String responseBody = om.writeValueAsString(responseDTOs);
 
         System.out.println("test : " + responseBody);

--- a/src/test/java/com/example/demo/contactTest.java
+++ b/src/test/java/com/example/demo/contactTest.java
@@ -1,2 +1,162 @@
-package com.example.demo;public class contactTest {
+package com.example.demo;
+
+import com.example.demo.account.Account;
+import com.example.demo.account.AccountJPARepository;
+import com.example.demo.account.interest.Interest;
+import com.example.demo.account.interest.InterestJPARepository;
+import com.example.demo.account.userInterest.UserInterest;
+import com.example.demo.account.userInterest.UserInterestJPARepository;
+import com.example.demo.mentoring.MentorPost;
+import com.example.demo.mentoring.MentorPostJPARepostiory;
+import com.example.demo.mentoring.contact.ContactJPARepository;
+import com.example.demo.mentoring.contact.ContactResponse;
+import com.example.demo.mentoring.contact.ContactService;
+import com.example.demo.mentoring.contact.NotConnectedRegisterUser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class contactTest {
+
+    @Autowired
+    private MentorPostJPARepostiory mentorPostJPARepostiory;
+    @Autowired
+    private AccountJPARepository accountJPARepository;
+    @Autowired
+    private ContactJPARepository contactJPARepository;
+    @Autowired
+    private UserInterestJPARepository userInterestJPARepository;
+    @Autowired
+    private InterestJPARepository interestJPARepository;
+
+    @Autowired
+    private ContactService contactService;
+
+    @Autowired
+    private ObjectMapper om;
+
+    Account account1;
+
+    @BeforeEach
+    void setUp() {
+        account1 = Account.builder()
+                .id(1)
+                .email("anjdal64@gmail.com")
+                .password("asdf1234!")
+                .firstname("aaa")
+                .lastname("Seung")
+                .country("Korea")
+                .age(21)
+                .role(Account.Role.MENTOR)
+                .build();
+        Account account2 = Account.builder()
+                .id(2)
+                .email("anjdal44@gmail.com")
+                .password("asdf1234!")
+                .firstname("bbb")
+                .lastname("Seung")
+                .country("Korea")
+                .age(21)
+                .role(Account.Role.MENTEE)
+                .build();
+        Account account3 = Account.builder()
+                .id(3)
+                .email("anjdal66@gmail.com")
+                .password("asdf1234!")
+                .firstname("ccc")
+                .lastname("Seung")
+                .country("Korea")
+                .age(21)
+                .role(Account.Role.MENTEE)
+                .build();
+
+        accountJPARepository.save(account1);
+        accountJPARepository.save(account2);
+        accountJPARepository.save(account3);
+
+        Interest interest = Interest.builder()
+                .id(1)
+                .tag("K-POP")
+                .build();
+
+        interestJPARepository.save(interest);
+
+
+        UserInterest userInterest1 = UserInterest.builder()
+                .id(1)
+                .user(account1)
+                .interest(interest)
+                .build();
+        UserInterest userInterest2 = UserInterest.builder()
+                .id(2)
+                .user(account2)
+                .interest(interest)
+                .build();
+        UserInterest userInterest3 = UserInterest.builder()
+                .id(3)
+                .user(account3)
+                .interest(interest)
+                .build();
+
+        userInterestJPARepository.save(userInterest1);
+        userInterestJPARepository.save(userInterest2);
+        userInterestJPARepository.save(userInterest3);
+
+        MentorPost mentorPost = MentorPost.builder()
+                .writer(account1)
+                .title("가나다라마바사")
+                .build();
+
+        MentorPost mentorPost2 = MentorPost.builder()
+                .writer(account1)
+                .title("아자차카타파하")
+                .build();
+
+        mentorPostJPARepostiory.save(mentorPost);
+        mentorPostJPARepostiory.save(mentorPost2);
+
+
+        NotConnectedRegisterUser mentee1 = NotConnectedRegisterUser.builder()
+                .id(1)
+                .mentorPost(mentorPost)
+                .menteeUser(account2)
+                .state(NotConnectedRegisterUser.State.AWAIT)
+                .build();
+        NotConnectedRegisterUser mentee2 = NotConnectedRegisterUser.builder()
+                .id(2)
+                .mentorPost(mentorPost)
+                .menteeUser(account3)
+                .state(NotConnectedRegisterUser.State.AWAIT)
+                .build();
+        // 문제점 : save 를 하기 위해 notConnected~ table 을 조회, mentorPost table 을 조회, account table 을 조회함
+        // 나중에 고쳐야할 듯 하다.
+        contactJPARepository.save(mentee1);
+        contactJPARepository.save(mentee2);
+    }
+
+    @Test
+    void test() throws Exception {
+
+        List<ContactResponse.MentorPostDTO> responseDTOs = contactService.findAll(account1);
+
+        List<UserInterest> menteeInterests = userInterestJPARepository.findAllById(2);
+        List<UserInterest> userInterests = userInterestJPARepository.findAll();
+
+        System.out.println(menteeInterests.size());
+
+        String responseBody = om.writeValueAsString(responseDTOs);
+
+        System.out.println("test : " + responseBody);
+
+    }
 }

--- a/src/test/java/com/example/demo/contactTest.java
+++ b/src/test/java/com/example/demo/contactTest.java
@@ -1,0 +1,2 @@
+package com.example.demo;public class contactTest {
+}


### PR DESCRIPTION
### Summary

- contact 화면 조회를 위해 **interest, userInterst, mentorPost 에서의 테이블과 JPA 를 추가**하였습니다.
- **멘토 기준 contact 화면 조회 기능**을 추가하였습니다.
- findAll 함수 설명은 아래 주석으로 적어놓았습니다.
- 아직 데이터가 없어서, 테스트를 진행할 때 임의로 값을 넣고 진행했습니다.

### 테스트
**멘토, 멘티 부분 펼치기 전**
![image](https://github.com/Step3-kakao-tech-campus/Team18_BE/assets/111727212/98dfbe14-9674-4655-8dd2-1891fe6f845f)

**멘토, 멘티 부분 펼친 후**
![image](https://github.com/Step3-kakao-tech-campus/Team18_BE/assets/111727212/f8867672-d2f8-4af1-bc82-a913468056df)

### 추후 진행 예정
- account 와 user 이름을 혼용해서 사용해서, Account 가 User 로 바뀐 뒤에 한번 더 코드를 수정할 예정입니다.
- 아직 쿼리문을 제대로 못살펴봐서, 여러번 select 가 발생하는 부분 있으면 fetch join 으로 쿼리문을 수정할 예정입니다.
- country 테이블이 생기면, 다시 수정할 예정입니다.
- 예외처리 코드를 작성할 예정입니다.

Related : #11 